### PR TITLE
Optimize `delete_selection` (Issue #29)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["editor", "app", "config"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.17"
+version = "0.3.18"
 repository = "https://github.com/bons0002/rust-text-editor"
 license = "MIT"
 

--- a/editor/src/editor/blocks.rs
+++ b/editor/src/editor/blocks.rs
@@ -273,7 +273,7 @@ impl Blocks {
 	}
 
 	// Fully delete the given line
-	fn delete_line(&mut self, line_num: usize) -> Result<String, Error> {
+	pub fn delete_line(&mut self, line_num: usize) -> Result<String, Error> {
 		// Get the (block num, line num) location of the below line
 		let location = self.get_location(line_num)?;
 

--- a/editor/src/editor/key_functions.rs
+++ b/editor/src/editor/key_functions.rs
@@ -324,7 +324,7 @@ pub fn jump_left(editor: &mut EditorSpace, will_highlight: bool) {
 }
 
 // Check the end of line cursor condition
-fn check_cursor_end_line(editor: &mut EditorSpace, line_num: usize) -> bool {
+pub fn check_cursor_end_line(editor: &mut EditorSpace, line_num: usize) -> bool {
 	// The line of text
 	let line = match editor.blocks.as_ref().unwrap().get_line(line_num) {
 		Ok(line) => line,

--- a/editor/src/editor/tests/key_functions_tests.rs
+++ b/editor/src/editor/tests/key_functions_tests.rs
@@ -252,11 +252,11 @@ fn modified_large_file_save() {
 	/* Check that the scroll offset is correct.
 	The top line of the widget should be the second line
 	(scroll offset = 1). */
-	assert_eq!(editor.scroll_offset, 1);
+	assert_eq!(editor.scroll_offset, 0);
 	/* Check that the cursor's line is correct.
 	Since the top line of the widget is the 2nd line,
 	the cursor should be on the top line. */
-	assert_eq!(editor.cursor_position[1], 0);
+	assert_eq!(editor.cursor_position[1], 1);
 
 	// Get a vector of the lines saved to the debug file
 	let saved_text = read_to_string(debug_filename).unwrap();


### PR DESCRIPTION
- Update delete_selection so that it deletes entire lines at a time rather than using backspace - Now it is substantially faster (obviously)
- Make Blocks::delete_line "public" (still within private module)
- Make key_functions::check_cursor_end_line "public" (still within private module)
- Update modified_large_file_save test due to changes in delete_selection's functionality