### PR TITLE
Implement `redo` (Issue #5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["editor", "app", "config", "stack"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.25"
+version = "0.3.26"
 repository = "https://github.com/bons0002/rust-text-editor"
 license = "MIT"
 

--- a/editor/src/editor/input_handlers.rs
+++ b/editor/src/editor/input_handlers.rs
@@ -1,6 +1,6 @@
 use super::{
 	copy_paste, editing_keys, highlight_keys, key_functions, navigation_keys, save_key,
-	EditorSpace, KeyCode,
+	EditorSpace, KeyCode, StackChoice,
 };
 
 pub fn no_modifiers(editor: &mut EditorSpace, code: KeyCode) {
@@ -120,7 +120,11 @@ pub fn control_modifier(editor: &mut EditorSpace, code: KeyCode, break_loop: &mu
 		}
 		// Undo a change
 		KeyCode::Char('z') => {
-			key_functions::undo(editor);
+			key_functions::undo_redo(editor, StackChoice::Undo);
+		}
+		// Redo a change
+		KeyCode::Char('r') => {
+			key_functions::undo_redo(editor, StackChoice::Redo);
 		}
 		// Jump to the next word
 		KeyCode::Right => {

--- a/editor/src/editor/key_functions.rs
+++ b/editor/src/editor/key_functions.rs
@@ -3,7 +3,8 @@
 
 use super::{
 	blocks::Blocks, ClipboardProvider, EditorSpace, File, IndexedParallelIterator,
-	IntoParallelIterator, OpenOptions, ParallelExtend, ParallelIterator, UnicodeSegmentation,
+	IntoParallelIterator, OpenOptions, ParallelExtend, ParallelIterator, StackChoice,
+	UnicodeSegmentation,
 };
 
 use unicode_segmentation::GraphemeCursor;
@@ -38,12 +39,18 @@ pub fn check_cursor_end_line(editor: &mut EditorSpace) -> bool {
 		&& editor.cursor_position[0] < editor.width
 }
 
-// Calls the UnRedoStack undo and sets the editor's state
-pub fn undo(editor: &mut EditorSpace) {
+// Calls the UnRedoStack undo or redo and sets the editor's state
+pub fn undo_redo(editor: &mut EditorSpace, stack_choice: StackChoice) {
 	// Get the current editor state
 	let state = editor.get_unredo_state();
-	// Take the undo action and return the new editor state
-	let state = editor.unredo_stack.undo(state);
+	// Either undo or redo
+	let state = match stack_choice {
+		// Take the undo action and return the new editor state
+		StackChoice::Undo => editor.unredo_stack.undo(state),
+		// Take the redo action and return the new editor state
+		StackChoice::Redo => editor.unredo_stack.redo(state),
+	};
+
 	// Set the new editor's state
 	editor.stored_position = state.0;
 	editor.text_position = state.1;

--- a/editor/src/editor/tests/key_functions_tests.rs
+++ b/editor/src/editor/tests/key_functions_tests.rs
@@ -858,7 +858,7 @@ fn jump_down_test() {
 
 // Test the length of the undo stack is updated properly
 #[test]
-fn undo_stack_length() {
+fn unredo_stack_length() {
 	// Create an editor over the HIGHLIGHT_FILE
 	let mut editor = construct_editor(HIGHLIGHT_FILE);
 
@@ -884,11 +884,12 @@ fn undo_stack_length() {
 	let state = editor.get_unredo_state();
 	let _ = editor.unredo_stack.undo(state);
 	assert_eq!(editor.unredo_stack.len(StackChoice::Undo), 2);
+	assert_eq!(editor.unredo_stack.len(StackChoice::Redo), 1);
 }
 
 // Test undoing after deleting a selection of text
 #[test]
-fn undo_delete_selection() {
+fn unredo_delete_selection() {
 	// Create an editor over the HIGHLIGHT_FILE
 	let mut editor = construct_editor(HIGHLIGHT_FILE);
 
@@ -905,11 +906,17 @@ fn undo_delete_selection() {
 	let selection_after = editor.selection.clone();
 
 	// Undo
-	undo(&mut editor);
+	undo_redo(&mut editor, StackChoice::Undo);
 	// Check that the selections are different
 	assert_ne!(selection_after, editor.selection);
 	// Check that it reverted to the original selection
 	assert_eq!(selection_before, editor.selection);
+
+	// Redo
+	undo_redo(&mut editor, StackChoice::Redo);
+	// Check that the states have returned to normal
+	assert_ne!(selection_before, editor.selection);
+	assert_eq!(selection_after, editor.selection);
 }
 
 /*

--- a/editor/src/editor/unredo_stack.rs
+++ b/editor/src/editor/unredo_stack.rs
@@ -67,6 +67,24 @@ impl UnRedoStack {
 		}
 	}
 
+	// Pop the top redo state and return it. Push to the undo stack as well
+	pub fn redo(&mut self, editor_state: UnRedoState) -> UnRedoState {
+		match self.redo_stack.pop() {
+			// If the redo stack wasn't empty
+			Some(state) => {
+				// Push the passed editor_state (current state) to the undo stack
+				self.undo_stack.push(editor_state);
+				// Return the popped
+				state.clone()
+			}
+			// If the redo stack is empty
+			None => {
+				// Return the current state so nothing changes
+				editor_state
+			}
+		}
+	}
+
 	// Used for debugging
 	#[allow(unused)]
 	pub fn len(&self, stack: StackChoice) -> usize {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -30,7 +30,7 @@ pub mod editor {
 		highlight_keys::{self, selection::Selection},
 		navigation_keys, save_key,
 	};
-	use unredo_stack::{UnRedoStack, UnRedoState};
+	use unredo_stack::{stack_choice::StackChoice, UnRedoStack, UnRedoState};
 
 	// Contains the Blocks struct
 	mod blocks;


### PR DESCRIPTION
Implement both the `undo` and `redo` functions. `undo` was created before #32 was merged into `unstable` and is therefore already merged