### PR TITLE
38 implement cut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["editor", "app", "config", "stack"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.26"
+version = "0.3.27"
 repository = "https://github.com/bons0002/rust-text-editor"
 license = "MIT"
 

--- a/editor/src/editor/input_handlers.rs
+++ b/editor/src/editor/input_handlers.rs
@@ -106,16 +106,25 @@ pub fn control_modifier(editor: &mut EditorSpace, code: KeyCode, break_loop: &mu
 		KeyCode::Char('s') => save_key::save_key_combo(editor, false, ""),
 		// Break the loop to end the program
 		KeyCode::Char('q') => *break_loop = true,
-		// Paste text into the editor (if there is a clipboard)
+		// Paste text into the editor
 		KeyCode::Char('v') => {
+			// If a clipboard exists
 			if editor.clipboard.is_some() {
-				copy_paste::paste_from_clipboard(editor)
+				copy_paste::paste_from_clipboard(editor);
 			}
 		}
 		// Copy text from the editor and write it to the clipboard
 		KeyCode::Char('c') => {
+			// If a clipboard exists
 			if editor.clipboard.is_some() {
-				copy_paste::copy_to_clipboard(editor)
+				copy_paste::copy_to_clipboard(editor);
+			}
+		}
+		// Cut text (copy and delete a selection)
+		KeyCode::Char('x') => {
+			// If a clipboard exists
+			if editor.clipboard.is_some() {
+				copy_paste::cut(editor);
 			}
 		}
 		// Undo a change

--- a/editor/src/editor/key_functions/copy_paste.rs
+++ b/editor/src/editor/key_functions/copy_paste.rs
@@ -77,6 +77,19 @@ pub fn paste_from_clipboard(editor: &mut EditorSpace) {
 	}
 }
 
+// Call the copy function and delete the selection
+pub fn cut(editor: &mut EditorSpace) {
+	// Get the current editor state
+	let state = editor.get_unredo_state();
+	// Add a new undo state
+	editor.unredo_stack.auto_update(state, true);
+
+	// Copy the selection to the clipboard
+	copy_to_clipboard(editor);
+	// Delete the selection
+	editor.delete_selection();
+}
+
 /*
 =================================================
 			Copy Function Subroutines


### PR DESCRIPTION
I implemented the `cut` function to copy and delete a selection of text. I haven't written any tests because there is a bug in the `paste` function.

Closes #38 